### PR TITLE
avoid deprecated health endpoint

### DIFF
--- a/l8k/install.py
+++ b/l8k/install.py
@@ -189,7 +189,7 @@ def _wait_for_ls_ready():
         result = requests.get(health_url)
         assert result.ok
 
-    health_url = f"http://localhost:{K3D_LB_PORT}/health"
+    health_url = f"http://localhost:{K3D_LB_PORT}/_localstack/health"
     retry(_check_ready, sleep=2, retries=60)
 
 


### PR DESCRIPTION
The `/health` endpoint has been deprecated for quite a while and will be removed with `3.0`.
This PR migrates to the new endpoint (`/localstack/health`).